### PR TITLE
feat: add ability to set a custom url

### DIFF
--- a/example/pusher_dart_example.dart
+++ b/example/pusher_dart_example.dart
@@ -1,12 +1,12 @@
 import 'package:pusher_channels/pusher_channels.dart';
 
 void main() async {
-  final pusher = Pusher(key: 'YOUR_APP_KEY');
+  final pusher = Pusher();
+  pusher.connection = Connection(url: 'localhost', key: 'YOUR_APP_KEY', version: pusher.version, protocol: pusher.protocol.toString(), eventHandler: pusher.connectionHandler);
   await pusher.connect();
   final channel = pusher.subscribe('channel');
   channel.bind('event', (event) {
     print('WOW event: $event');
   });
   await Future.delayed(Duration(seconds: 60));
-
 }

--- a/lib/src/connection.dart
+++ b/lib/src/connection.dart
@@ -7,15 +7,22 @@ typedef EventHandler = void Function(
     String eventName, String channelName, Map<String, dynamic> data);
 
 class Connection {
-  final String url;
+  late final String url;
   late final WebSocket _socket;
   final Map<String, Function(dynamic event)> _eventCallbacks = {};
   final EventHandler eventHandler;
 
   Connection({
-    required this.url,
     required this.eventHandler,
+    required String url,
+    required String key,
+    required String version,
+    required String protocol,
+    bool secure = true,
+    String? client,
   }) {
+    this.url = '${secure ? 'wss' : 'ws'}://$url/app/$key?${client != null ? 'client=$client&' : ''}version=$version&protocol=$protocol';
+
     bind('pusher:connection_established', _connect_handler);
     bind('pusher:ping', _ping_handler);
     bind('pusher:error', _pusher_error_handler);

--- a/lib/src/not_initialized.dart
+++ b/lib/src/not_initialized.dart
@@ -1,0 +1,1 @@
+class NotInitialized extends Error {}

--- a/lib/src/pusher.dart
+++ b/lib/src/pusher.dart
@@ -1,27 +1,29 @@
 import 'package:pusher_channels/pusher_channels.dart';
+import 'package:pusher_channels/src/not_initialized.dart';
 
 typedef PusherGlobalCallback = void Function(
     String channelName, String eventName, dynamic data);
 
 class Pusher {
-  final String url = 'pusher.com:443';
-  final String cluster;
-  final String client = 'pusher.dart';
-  final String key;
+  Connection? _connection;
+
   final String version = '0.1.3';
   final int protocol = 6;
 
   PusherGlobalCallback? globalCallback;
-  late final Connection connection;
   final Map<String, Channel> channels = {};
 
-  Pusher({required this.key, this.cluster = 'eu', Connection? connection}) {
-    this.connection = connection ??
-        Connection(
-          url:
-              'wss://ws-$cluster.$url/app/$key?client=$client&version=$version&protocol=$protocol',
-          eventHandler: connectionHandler,
-        );
+  Pusher();
+
+  Connection get connection {
+    if (_connection == null) {
+      throw NotInitialized();
+    }
+    return _connection!;
+  }
+
+  set connection(Connection connection) {
+    _connection = connection;
   }
 
   Future<void> connect() async {

--- a/test/pusher_test.dart
+++ b/test/pusher_test.dart
@@ -1,5 +1,6 @@
 import 'package:mocktail/mocktail.dart';
 import 'package:pusher_channels/pusher_channels.dart';
+import 'package:pusher_channels/src/not_initialized.dart';
 import 'package:test/test.dart';
 
 class MockConnection extends Mock implements Connection {}
@@ -11,11 +12,21 @@ void main() {
     late Pusher pusher;
 
     setUp(() {
-      pusher = Pusher(key: 'my-key', connection: MockConnection());
+      pusher = Pusher();
+      pusher.connection = MockConnection();
     });
 
     tearDown(() {
       reset(pusher.connection);
+    });
+
+    test('throw not initialized exception when connection is not set', () async {
+      try {
+        Pusher().subscribe('test');
+        expect(true, false);
+      } catch (e) {
+        expect(e is NotInitialized, true);
+      }
     });
 
     test('connect', () async {


### PR DESCRIPTION
Add ability to set a custom pusher server, and not depend on `pusher.com`.