### PR TITLE
feat: add custom periodic connection checker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.4.0 - January 26, 2023
+- Add a dedicated checker for connection status. 
+  This will improve the automatic reconnection resilience.
+
 ## 0.3.0 - November 6, 2022
 - Replace pedantic by linter
 

--- a/lib/src/pusher.dart
+++ b/lib/src/pusher.dart
@@ -8,7 +8,7 @@ class Pusher {
   final String cluster;
   final String client = 'pusher.dart';
   final String key;
-  final String version = '0.3.0';
+  final String version = '0.4.0';
   final int protocol = 6;
 
   PusherGlobalCallback? globalCallback;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: pusher_channels
 description: A pure Dart pusher channels client
-version: 0.3.0
+version: 0.4.0
 homepage: https://github.com/indaband/pusher_channels
 documentation: https://github.com/indaband/pusher_channels/blob/main/README.md
 


### PR DESCRIPTION
feat: add custom periodic connection checker

this will remove the responsibility of pong check to reconnect and will make the auto reconnection more resilient.

ps: for now we dont have test for the connection layer. we should figure out in the future how to test it.