### PR TITLE
fix: error handling issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.5.2 - February 6, 2024
+- Fixes error handler
+- Use dart's developer log instead of print
+
 ## 0.5.1 - February 6, 2024
 - Update sdk requirements
 

--- a/lib/src/connection.dart
+++ b/lib/src/connection.dart
@@ -36,7 +36,7 @@ class Connection {
   }
 
   void _connectHandler(data) {
-    log('Connection: Establisheds first connection $data', name: _kLogName);
+    log('Established first connection: $data', name: _kLogName);
   }
 
   void _pongHandler(data) {
@@ -53,7 +53,6 @@ class Connection {
     if (pongReceived) {
       pongReceived = false;
       sendPing();
-      return;
     }
   }
 
@@ -73,7 +72,12 @@ class Connection {
         log('No error code supplied', name: _kLogName);
       }
     } catch (e, s) {
-      log('Could not handle connection error', error: e, stackTrace: s, name: _kLogName,);
+      log(
+        'Could not handle connection error',
+        error: e,
+        stackTrace: s,
+        name: _kLogName,
+      );
     }
   }
 
@@ -92,10 +96,9 @@ class Connection {
       _socket?.listen(onMessage);
       sendPing();
       _resetCheckPong();
-
       afterConnect();
     } catch (e, s) {
-      log('Connection: connection error', error: e, stackTrace: s, name: _kLogName);
+      log('Connection error', error: e, stackTrace: s, name: _kLogName);
     }
     _resetCheckConnection();
   }

--- a/lib/src/connection.dart
+++ b/lib/src/connection.dart
@@ -126,11 +126,20 @@ class Connection {
     }
   }
 
-  void sendEvent(String eventName, Map<String, String> data) {
+  void sendEvent(
+    String eventName,
+    dynamic data, {
+    String channelName = '',
+  }) {
     final event = {
       'event': eventName,
       'data': data,
     };
+
+    if (channelName.isNotEmpty) {
+      event['channel'] = channelName;
+    }
+
     _socket?.add(jsonEncode(event));
   }
 

--- a/lib/src/connection.dart
+++ b/lib/src/connection.dart
@@ -67,9 +67,10 @@ class Connection {
         final code = data['code'];
         if (code != null && code >= 4200 && code < 4300) {
           reconnect();
+          log('Trying to reconnect after error $code', name: _kLogName);
         }
       } else {
-        log('No error code supplied', name: _kLogName);
+        log('Received pusher:error without code: $data', name: _kLogName);
       }
     } catch (e, s) {
       log(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: pusher_channels
 description: A pure Dart pusher channels client
-version: 0.5.1
+version: 0.5.2
 homepage: https://github.com/indaband/pusher_channels
 documentation: https://github.com/indaband/pusher_channels/blob/main/README.md
 


### PR DESCRIPTION
Sometimes the event bind `pusher:error` would receive a payload that doesn't have a `code` and we're not properly checking the types there. This PR updates it with logs from `dart:developer` and properly handles the nullable code