### PR TITLE
feat: add support for named global callbacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.6.0 - June 4, 2024
+- Add support for named global callbacks
+
 ## 0.5.3 - March 20, 2024
 - Fixes error handler when subscribing to channel
 

--- a/lib/src/channel.dart
+++ b/lib/src/channel.dart
@@ -6,6 +6,7 @@ class Channel {
   final String name;
   Map<String, Function(dynamic event)> eventCallbacks = {};
   GlobalCallback? globalCallback;
+  Map<String, GlobalCallback> namedGlobalCallbacks = {};
 
   void bind(String eventName, Function(dynamic event) callback) {
     eventCallbacks[eventName] = callback;
@@ -23,10 +24,21 @@ class Channel {
     globalCallback = null;
   }
 
+  void bindNamedGlobal(String callbackName, GlobalCallback callback) {
+    namedGlobalCallbacks[callbackName] = callback;
+  }
+
+  void unbindNamedGlobal(String callbackName) {
+    namedGlobalCallbacks.remove(callbackName);
+  }
+
   void handleEvent(String eventName, Map<String, dynamic> data) {
     if (eventCallbacks.containsKey(eventName)) {
       eventCallbacks[eventName]?.call(data);
     }
     globalCallback?.call(eventName, data);
+    for (final callback in namedGlobalCallbacks.values) {
+      callback.call(eventName, data);
+    }
   }
 }

--- a/lib/src/pusher.dart
+++ b/lib/src/pusher.dart
@@ -8,7 +8,7 @@ class Pusher {
   final String cluster;
   final String client = 'pusher.dart';
   final String key;
-  final String version = '0.5.3';
+  final String version = '0.6.0';
   final int protocol = 6;
 
   PusherGlobalCallback? globalCallback;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: pusher_channels
 description: A pure Dart pusher channels client
-version: 0.5.3
+version: 0.6.0
 homepage: https://github.com/indaband/pusher_channels
 documentation: https://github.com/indaband/pusher_channels/blob/main/README.md
 

--- a/test/channel_test.dart
+++ b/test/channel_test.dart
@@ -28,6 +28,19 @@ void main() {
       );
     });
 
+    test('bindNamedGlobal', () {
+      var value = '';
+      const callbackName = 'callbackName';
+      channel.bindNamedGlobal(callbackName, (eventName, data) {
+        value = 'event $eventName with data $data has been executed';
+      });
+      channel.handleEvent('event-name', {'key': 'value'});
+      expect(
+        value,
+        'event event-name with data {key: value} has been executed',
+      );
+    });
+
     test('unbind', () {
       channel.bind('event-name', (_) {});
       expect(channel.eventCallbacks.containsKey('event-name'), true);
@@ -42,6 +55,15 @@ void main() {
 
       channel.unbindGlobal();
       expect(channel.globalCallback == null, true);
+    });
+
+    test('unbindNamedGlobal', () {
+      const callbackName = 'callbackName';
+      channel.bindNamedGlobal(callbackName, (_, __) {});
+      expect(channel.namedGlobalCallbacks.containsKey(callbackName), true);
+
+      channel.unbindNamedGlobal(callbackName);
+      expect(channel.namedGlobalCallbacks.containsKey(callbackName), false);
     });
   });
 }


### PR DESCRIPTION
with that will be possible to have multiple global callbacks per channel