### PR TITLE
chore: improve bindNamedGlobal tests

### DIFF
--- a/test/channel_test.dart
+++ b/test/channel_test.dart
@@ -28,17 +28,48 @@ void main() {
       );
     });
 
-    test('bindNamedGlobal', () {
-      var value = '';
-      const callbackName = 'callbackName';
-      channel.bindNamedGlobal(callbackName, (eventName, data) {
-        value = 'event $eventName with data $data has been executed';
+    group('bindNamedGlobal', () {
+      test('should handle event properly', () {
+        var value = '';
+        const callbackName = 'callbackName';
+        channel.bindNamedGlobal(callbackName, (eventName, data) {
+          value = 'event $eventName with data $data has been executed';
+        });
+        channel.handleEvent('event-name', {'key': 'value'});
+        expect(
+          value,
+          'event event-name with data {key: value} has been executed',
+        );
       });
-      channel.handleEvent('event-name', {'key': 'value'});
-      expect(
-        value,
-        'event event-name with data {key: value} has been executed',
-      );
+
+      test('should add callback to namedGlobalCallbacks', () {
+        final callbackName = 'testCallback';
+        void globalCallback(String eventName, dynamic data) =>
+            print('globalCallback');
+
+        channel.bindNamedGlobal(callbackName, globalCallback);
+        expect(
+          channel.namedGlobalCallbacks[callbackName],
+          globalCallback,
+        );
+      });
+
+      test('should overwrite an existing callback with the same name', () {
+        final callbackName = 'testCallback';
+        void oldGlobalCallback(String eventName, dynamic data) =>
+            print('oldGlobalCallback');
+
+        void newGlobalCallback(String eventName, dynamic data) =>
+            print('newGlobalCallback');
+
+        channel.bindNamedGlobal(callbackName, oldGlobalCallback);
+        channel.bindNamedGlobal(callbackName, newGlobalCallback);
+
+        expect(
+          channel.namedGlobalCallbacks[callbackName],
+          newGlobalCallback,
+        );
+      });
     });
 
     test('unbind', () {


### PR DESCRIPTION
the `bindNamedGlobal` method tests were not checking the callback names properly